### PR TITLE
Add the `cached-install-poetry` action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,16 @@ jobs:
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run Pre-Commit Checks
         run: pre-commit run --show-diff-on-failure --color=always --all-files
+
+  test-cached-install-poetry:
+    name: 'Test "Cached Install Poetry"'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v2
+      - name: Run Action
+        uses: ./cached-install-poetry

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ This repository contains custom GitHub actions required for badook AI CI/CD pipe
 This repository uses [`pre-commit`](https://pre-commit.com/) for checking files committed to the repository. Install `pre-commit` by following the [installation guide](https://pre-commit.com/#install).
 
 Locally install the pre-commit hook by executing `pre-commit install` in your repo folder.
+
+## Included Actions
+
+### Cached Install Poetry
+This action installs [Poetry](https://python-poetry.org/) in a cached manner, as well as optionally installing [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning). It assumes that Python is already installed on the runner.
+
+Internally, the actions uses the following 3rd-party actions:
+* [snok/install-poetry](https://github.com/snok/install-poetry)

--- a/cached-install-poetry/action.yml
+++ b/cached-install-poetry/action.yml
@@ -1,0 +1,45 @@
+name: 'Cached Install Poetry'
+description: 'This action installs Poetry in a cached manner, as well as optionally installing poetry-dynamic-versioning. It assumes that Python is already installed on the runner.'
+inputs:
+  version:
+    description: 'The poetry version to install'
+    required: true
+  dynamic-versioning:
+    description: 'Should poetry dynamic versioning be installed'
+    required: false
+    default: false
+  virtualenvs-create:
+    description: "Whether Poetry should create a virtualenv or not"
+    required: false
+    default: "true"
+  virtualenvs-in-project:
+    description: "Whether Poetry should create virtualenvs in the project directory or not"
+    required: false
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    - name: Get Python Version
+      id: get-python-version
+      shell: bash
+      run: echo "::set-output name=version::$(python --version)"
+    - name: Load cached Poetry installation
+      uses: actions/cache@v2
+      with:
+        path: ~/.local
+        key: poetry-${{ inputs.version }}-${{ steps.get-python-version.outputs.version }}-install-with-dynamic-versioning-${{ inputs.dynamic-versioning }}
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: ${{ inputs.version }}
+        virtualenvs-create: ${{ inputs.virtualenvs-create }}
+        virtualenvs-in-project: ${{ inputs.virtualenvs-in-project }}
+    #--------------------------------------------------------------------------------
+    #  Note: The installation method will change when plugins are supported:
+    #  https://github.com/mtkennerly/poetry-dynamic-versioning/issues/39 is completed
+    #--------------------------------------------------------------------------------
+    - name: Install Poetry Dynamic Versioning
+      shell: bash
+      run: |
+        source ~/.local/venv/bin/activate
+        [[ "${{ inputs.dynamic-versioning }}" = true ]] && python -m pip install poetry-dynamic-versioning || true


### PR DESCRIPTION
This action installs [Poetry](https://python-poetry.org/) in a cached manner, as well as optionally installing [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning). It assumes that Python is already installed on the runner.