### PR TITLE
Add the 'tag-version' action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+jobs:
+  tag-version:
+    name: Tag Version
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Tag Version
+        uses: ./tag-version
+        with:
+          dry_run: false

--- a/.github/workflows/validate-semver.yml
+++ b/.github/workflows/validate-semver.yml
@@ -1,0 +1,26 @@
+name: Validate PR SemVer
+
+on:
+  pull_request_target:
+    branches: [ main ]
+    types: [ synchronize, labeled, unlabeled ]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: validate-labels-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate-semver:
+    name: Validate SemVer Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Check SemVer Labels
+        uses: ./tag-version
+        with:
+          dry_run: true

--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ Internally, the actions uses the following 3rd-party actions:
 
 ### Cached Poetry Install Dependencies
 This action executes `poetry install` in a cached manner. It caches the created virtual environment for future use. The action assumes that poetry is already installed.
+
+### Tag Version
+This action is used to automatically manage repo version following pull-requests. It also comments on the PR with the expected/actual version for the tag following the PR.
+
+By default, it assumes the following labels (or a subset of them) exists on the repository:
+* `semver:prerelease`
+* `semver:prepatch`
+* `semver:preminor`
+* `semver:premajor`
+* `semver:patch`
+* `semver:minor`
+* `semver:major`
+
+Internally, the actions uses the following 3rd-party actions:
+* [zwaldowski/match-label-action](https://github.com/zwaldowski/match-label-action)
+* [zwaldowski/semver-release-action](https://github.com/zwaldowski/semver-release-action)
+* [peter-evans/find-comment](https://github.com/peter-evans/find-comment)
+* [peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment)

--- a/tag-version/action.yml
+++ b/tag-version/action.yml
@@ -1,0 +1,69 @@
+name: 'Tag Version'
+description: 'This action is used to automatically manage repo version following pull-requests. It also comments on the PR with the expected/actual version for the tag following the PR.'
+inputs:
+  github_token:
+    description: 'GITHUB_TOKEN or a repo scoped PAT.'
+    default: ${{ github.token }}
+    required: false
+  allowed_labels:
+    description: 'The allowed labels to check for'
+    required: false
+    default: semver:major,semver:minor,semver:patch,semver:premajor,semver:preminor,semver:prepatch,semver:prerelease
+  dry_run:
+    description: 'A flag indicating whether the commit should be tagged'
+    required: true
+outputs:
+  bump:
+    description: 'The type of version bump detected (major, minor, patch, etc.)'
+    value: ${{ steps.bump.outputs.match }}
+  version:
+    description: 'The expected version'
+    value: ${{ steps.tag-version.outputs.version }}
+runs:
+  using: "composite"
+  steps:
+    - name: Get Version Bump Label
+      id: bump-label
+      uses: zwaldowski/match-label-action@v2
+      with:
+        allowed: ${{ inputs.allowed_labels }}
+    - name: Get Version Bump
+      id: bump
+      shell: bash
+      run: echo "::set-output name=match::$(echo  ${{ steps.bump-label.outputs.match }} | sed -e 's/^semver://')"
+    - name: Tag Version
+      id: tag-version
+      uses: zwaldowski/semver-release-action@v2
+      with:
+        bump: ${{ steps.bump.outputs.match }}
+        github_token: ${{ inputs.github_token }}
+        prefix: v
+        preid: pre
+        dry_run: ${{ inputs.dry_run }}
+
+    # Comment with expected version
+    - name: Find Comment
+      uses: peter-evans/find-comment@v1
+      id: fc
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Output Version
+        token: ${{ inputs.github_token }}
+    - name: Calculate opening phrase
+      id: calculate-phrase
+      shell: bash
+      run: |
+        if ${{ inputs.dry_run }}; then PHRASE="Expected"; else PHRASE="Published"; fi;
+        echo "::set-output name=phrase::$PHRASE"
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        comment-id: ${{ steps.fc.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          ## Output Version :rocket:
+          ${{ steps.calculate-phrase.outputs.phrase }} output version: **${{ steps.tag-version.outputs.version }}**
+          This is a **${{ steps.bump.outputs.match }}** version.
+        edit-mode: replace
+        token: ${{ inputs.github_token }}


### PR DESCRIPTION
This action is used to automatically manage repo version following pull-requests. It also comments on the PR with the expected/actual version for the tag following the PR.

By default, it assumes the following labels (or a subset of them) exists on the repository:
* `semver:prerelease`
* `semver:prepatch`
* `semver:preminor`
* `semver:premajor`
* `semver:patch`
* `semver:minor`
* `semver:major`